### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # helmchart
 One helm chart to rule them all
+
+Repository located at <https://github.com/m-augustine/helmchart/>


### PR DESCRIPTION
add link to repo, navigating to helm chart in other project configs (example https://github.com/CalcGuard/devops/blob/main/helm/base/cert-manager/helmfile.yaml#L12) leads to GitHub pages build from readme, which seems like a dead end